### PR TITLE
chore: add `oxlint`/`oxfmt` npm scripts and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "type-check": "vue-tsc --noEmit"
+    "type-check": "vue-tsc --noEmit",
+    "lint": "oxlint .",
+    "format": "oxfmt --check .",
+    "format:write": "oxfmt --write ."
   },
   "dependencies": {
     "axios": "^1.13.5",
@@ -39,7 +42,9 @@
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.3",
     "vite": "^5.4.20",
-    "vue-tsc": "^2.2.12"
+    "vue-tsc": "^2.2.12",
+    "oxlint": "latest",
+    "oxfmt": "latest"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
### Motivation
- Provide project-level commands to run Oxc linting and formatting from npm scripts so contributors can check and fix code style consistently.

### Description
- Added three npm scripts: `lint` (`oxlint .`), `format` (`oxfmt --check .`), and `format:write` (`oxfmt --write .`) to `package.json`.
- Added `oxlint` and `oxfmt` to `devDependencies` in `package.json` so the tools can be installed as part of the development toolchain.
- Kept existing `type-check` script (`vue-tsc --noEmit`) intact.

### Testing
- Ran `npm run type-check` which succeeded (`vue-tsc --noEmit`) ✅.
- Ran `npm run lint` which failed because the `oxlint` binary is not available in this environment (tool installation blocked) ⚠️.
- Ran `npm run format` which failed because the `oxfmt` binary is not available in this environment (tool installation blocked) ⚠️.
- Note: installing packages from the npm registry failed with HTTP 403 in this environment, so the `oxlint`/`oxfmt` binaries could not be downloaded and executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b2911fa48332aaa4af9d3e5a6d01)